### PR TITLE
Fix colo picom start

### DIFF
--- a/bin/colo
+++ b/bin/colo
@@ -56,6 +56,7 @@ dunst -verbosity crit -config $DOTSDIR/$mode/dunstrc-$mode &
 # finally, restart picom (because things can get a little
 # weird if we don't
 killall picom
+sleep 0.1
 picom --experimental-backends -b --config $DOTSDIR/picom.conf &
 
 sleep 0.1


### PR DESCRIPTION
I noticed that picom starts unstable if no delay is added. (if I run colo, picom doesn't start, and when I run the script again, everything works fine, picom does not always have time to die)